### PR TITLE
Faster relationship by building the set and the type bag while inserting

### DIFF
--- a/src/main/java/io/usethesource/vallang/impl/persistent/ValueFactory.java
+++ b/src/main/java/io/usethesource/vallang/impl/persistent/ValueFactory.java
@@ -34,11 +34,11 @@ public class ValueFactory extends io.usethesource.vallang.impl.fast.ValueFactory
 	}
 
 	public ISetWriter setWriter(Type upperBoundType) {
-		return new SetWriter(upperBoundType);
+		return new SetWriter(upperBoundType, (a,b) -> tuple(a,b));
 	}
 
 	public ISetWriter setWriter() {
-		return new SetWriter();
+		return new SetWriter((a,b) -> tuple(a,b));
 	}
 
 	public ISetWriter relationWriter(Type upperBoundType) {
@@ -46,7 +46,7 @@ public class ValueFactory extends io.usethesource.vallang.impl.fast.ValueFactory
 	}
 
 	public ISetWriter relationWriter() {
-		return new SetWriter();
+		return new SetWriter((a,b) -> tuple(a,b));
 	}
 
 	public ISet set(Type elementType) {


### PR DESCRIPTION
I did some profiling, and our current `SetWriter` first builds a stream, and then at the end iterates over the stream to build the actual set and construct a type set.

This double allocation & iteration is a bit expensive.

The new way of the set writer decides on the first Value if it's a normal set, or a binary relation. There is a special case where we start with binary tuples, yet a new value is not a binary tuple, in this case we switch back to the normal set, and have to rebuild the tuples. This special case is a degenerate for most of our use cases.