### PR TITLE
Arithmetic div by zero was flawed. Corrected and test added.

### DIFF
--- a/src/main/java/io/usethesource/vallang/impl/primitive/IntegerValue.java
+++ b/src/main/java/io/usethesource/vallang/impl/primitive/IntegerValue.java
@@ -9,6 +9,7 @@
  *
  *   * Arnold Lankamp - interfaces and implementation
  *   * Michael Steindorfer - Michael.Steindorfer@cwi.nl - CWI
+ *   * Toine Khonraad - a.khonraad@khonraad.nl 
  *******************************************************************************/
 package io.usethesource.vallang.impl.primitive;
 
@@ -339,13 +340,27 @@ import io.usethesource.vallang.visitors.IValueVisitor;
 	
 	@Override
 	public IInteger divide(IInteger other){
-		if(value == 0)
-			return this;
+		
 		if(other instanceof BigIntegerValue){
+			if ( ((BigIntegerValue) other).equals(BigInteger.ZERO) ) {
+				throw new IllegalArgumentException("Big Argument 'divisor' is 0");
+			}
 			return IntegerValue.newInteger(toBigInteger().divide(((ICanBecomeABigInteger) other).toBigInteger()));
 		}
 		
+		// other is an instance of IntegerValue
+		
+		/*
+		 * This optimization? doesn't hold
+		 * 
+		 * if(value == 0)
+		 *	return this;
+		 */
+
 		int otherIntValue = other.intValue();
+		if(otherIntValue == 0) {
+			throw new IllegalArgumentException("Argument 'divisor' is 0");
+		}
 		if(otherIntValue == 1)
 			return this;
 		return IntegerValue.newInteger(value / otherIntValue);

--- a/src/test/java/io/usethesource/vallang/basic/BasicValueSmokeTest.java
+++ b/src/test/java/io/usethesource/vallang/basic/BasicValueSmokeTest.java
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2017 CWI
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *
+ *   * Toine Khonraad - a.khonraad@khonraad.nl 
+ *******************************************************************************/
 package io.usethesource.vallang.basic;
 
 import java.net.URISyntaxException;
@@ -185,6 +196,29 @@ public final class BasicValueSmokeTest {
     assertEqual(vf.integer(0), vf.integer(0).abs());
     assertEqual(vf.rational(0, 1), vf.rational(0, 1).abs());
     assertEqual(vf.real(0), vf.real(0).abs());
+    
+    // Test division by zero
+    IInteger i0 = vf.integer(0);
+    IInteger i41 = vf.integer(41);
+    
+    boolean thrown = false;
+    try {
+    		i0.divide(i0);
+    } catch (IllegalArgumentException e) {
+        thrown = true;
+    }
+    assertTrue(thrown);
+    
+    thrown = false;
+    try {
+    		i41.divide(i0);
+    } catch (IllegalArgumentException e) {
+    		thrown = true;
+    }
+    assertTrue(thrown);
+    
+    
+    
   }
 
   @Test


### PR DESCRIPTION
Entering just "3/0" in the Rascal REPL correctly reports `ArithmeticException("/ by zero")`. However, entering "0/0" evaluates to 0, which I think is incorrect. As it turned out, this had to do with an 'optimisation' in the evaluation in the class `io.usethesource.vallang.impl.primitive.IntegerValue`.

I corrected and tested this. 