### PR TITLE
Refactoring away calendar implementation to use java8's data 

### DIFF
--- a/src/main/java/io/usethesource/vallang/exceptions/InvalidDateTimeException.java
+++ b/src/main/java/io/usethesource/vallang/exceptions/InvalidDateTimeException.java
@@ -8,4 +8,8 @@ public class InvalidDateTimeException extends FactTypeUseException {
 		super(message);
 	}
 
+	public InvalidDateTimeException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
 }

--- a/src/main/java/io/usethesource/vallang/io/StandardTextReader.java
+++ b/src/main/java/io/usethesource/vallang/io/StandardTextReader.java
@@ -604,7 +604,7 @@ public class StandardTextReader extends AbstractTextReader {
                     Integer.parseInt(timeString.substring(4,6)), // seconds
                     Integer.parseInt(timeString.substring(6,9)), // milliseconds
                     Integer.parseInt(timeString.substring(10,12)) * (negativeTZHours ? -1 : 1), // timezone hours
-                    Integer.parseInt(timeString.substring(12))); // timezone minutes
+                    Integer.parseInt(timeString.substring(12)) * (negativeTZHours ? -1 : 1)); // timezone minutes
         }
 
         private IValue readDateTime(Type expected) throws IOException, FactParseError {

--- a/src/main/java/io/usethesource/vallang/io/binary/message/IValueReader.java
+++ b/src/main/java/io/usethesource/vallang/io/binary/message/IValueReader.java
@@ -961,7 +961,7 @@ public class IValueReader {
         }
         else {
             assert year != -1;
-            return vf.datetime(year, month, day);
+            return vf.date(year, month, day);
         }
     }
 

--- a/src/main/java/io/usethesource/vallang/io/binary/message/IValueWriter.java
+++ b/src/main/java/io/usethesource/vallang/io/binary/message/IValueWriter.java
@@ -537,7 +537,7 @@ public class IValueWriter {
             public void visitDateTime(IDateTime dateTime) throws IOException {
                 writer.startMessage(IValueIDs.DateTimeValue.ID);
 
-                if (!dateTime.isTime()) {
+                if (dateTime.isDateTime() || dateTime.isDate()) {
                     writer.writeField(IValueIDs.DateTimeValue.YEAR, dateTime.getYear());
                     writer.writeField(IValueIDs.DateTimeValue.MONTH, dateTime.getMonthOfYear());
                     writer.writeField(IValueIDs.DateTimeValue.DAY, dateTime.getDayOfMonth());

--- a/src/test/java/io/usethesource/vallang/ValueProvider.java
+++ b/src/test/java/io/usethesource/vallang/ValueProvider.java
@@ -42,6 +42,7 @@ import io.usethesource.vallang.type.TypeStore;
  *    <li>IConstructor</li>
  *    <li>ITuple</li>
  *    <li>ISourceLocation</li>
+ *    <li>IDateTime</li>
  *    <li>Type</li></ul></p>
  *    
  *    <p>If the class under test has a static field called "store" of type TypeStore, then this
@@ -131,6 +132,7 @@ public class ValueProvider implements ArgumentsProvider {
     private static final Map<Class<? extends IValue>, BiFunction<TypeStore, ExpectedType, Type>> types = 
         Stream.<Tuple<Class<? extends IValue>, BiFunction<TypeStore, ExpectedType, Type>>>of(
             Tuple.of(IInteger.class,        (ts, n) -> tf.integerType()),
+            Tuple.of(IDateTime.class,       (ts, n) -> tf.dateTimeType()),
             Tuple.of(IBool.class,           (ts, n) -> tf.boolType()),
             Tuple.of(IReal.class,           (ts, n) -> tf.realType()),
             Tuple.of(IRational.class,       (ts, n) -> tf.rationalType()),

--- a/src/test/java/io/usethesource/vallang/basic/BinaryIoSmokeTest.java
+++ b/src/test/java/io/usethesource/vallang/basic/BinaryIoSmokeTest.java
@@ -32,6 +32,7 @@ import io.usethesource.vallang.ArgumentsMaxWidth;
 import io.usethesource.vallang.ExpectedType;
 import io.usethesource.vallang.GivenValue;
 import io.usethesource.vallang.IConstructor;
+import io.usethesource.vallang.IDateTime;
 import io.usethesource.vallang.IList;
 import io.usethesource.vallang.IValue;
 import io.usethesource.vallang.IValueFactory;
@@ -64,6 +65,11 @@ public final class BinaryIoSmokeTest extends BooleanStoreProvider {
             @ExpectedType("Boolean") 
             IConstructor t) throws FactTypeUseException, IOException {
         ioRoundTrip(vf, store, t);
+    }
+
+    @ParameterizedTest @ArgumentsSource(ValueProvider.class)
+    public void testDateTimeIO(IValueFactory vf, TypeStore ts, IDateTime value) throws IOException {
+        ioRoundTrip(vf, ts, value);
     }
     
     @ParameterizedTest @ArgumentsSource(ValueProvider.class)
@@ -205,8 +211,8 @@ public final class BinaryIoSmokeTest extends BooleanStoreProvider {
         try (IValueInputStream read = new IValueInputStream(new ByteArrayInputStream(buffer.toByteArray()), vf, () -> ts)) {
             IValue result = read.read();
             if (!value.equals(result)) {
-                String message = "Not equal:\n\t" + value + " : " + value.getType()
-                + "\n\t" + result + " : " + result.getType();
+                String message = "Not equal: \n\t" + value + " : " + value.getType() + "( " + value.getClass() + ")"
+                + "\n\t" + result + " : " + result.getType()  + "( " + result.getClass() + ")";
                 System.err.println("Test fail:");
                 System.err.println(message);
                 System.err.flush();
@@ -243,8 +249,8 @@ public final class BinaryIoSmokeTest extends BooleanStoreProvider {
         try (IValueInputStream read = new IValueInputStream(FileChannel.open(target.toPath(), StandardOpenOption.READ), vf, () -> ts)) {
             IValue result = read.read();
             if (!value.equals(result)) {
-                String message = "Not equal: size: " + fileSize +") \n\t" + value + " : " + value.getType()
-                + "\n\t" + result + " : " + result.getType();
+                String message = "Not equal: size: " + fileSize +") \n\t" + value + " : " + value.getType() + "( " + value.getClass() + ")"
+                + "\n\t" + result + " : " + result.getType()  + "( " + result.getClass() + ")";
                 System.err.println(message);
                 fail(message);
             }

--- a/src/test/java/io/usethesource/vallang/specification/IValueTests.java
+++ b/src/test/java/io/usethesource/vallang/specification/IValueTests.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import io.usethesource.vallang.IConstructor;
+import io.usethesource.vallang.IDateTime;
 import io.usethesource.vallang.IValue;
 import io.usethesource.vallang.IValueFactory;
 import io.usethesource.vallang.ValueProvider;


### PR DESCRIPTION
I've improved our random tests for generating date times, encovered a few bugs in the binary serializer and text serializer and decreased the size of the implementation of DateTime values.