### PR TITLE
Updated reflection logic to find cleaner in new place

### DIFF
--- a/src/main/java/io/usethesource/vallang/io/binary/util/FileChannelDirectInputStream.java
+++ b/src/main/java/io/usethesource/vallang/io/binary/util/FileChannelDirectInputStream.java
@@ -5,7 +5,6 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileChannel.MapMode;
@@ -14,7 +13,6 @@ import java.security.PrivilegedAction;
 import java.util.concurrent.atomic.AtomicReference;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import sun.misc.Unsafe;
 
 public class FileChannelDirectInputStream extends ByteBufferInputStream {
     private final FileChannel channel;

--- a/src/main/java/io/usethesource/vallang/io/binary/util/FileChannelDirectInputStream.java
+++ b/src/main/java/io/usethesource/vallang/io/binary/util/FileChannelDirectInputStream.java
@@ -1,13 +1,20 @@
 package io.usethesource.vallang.io.binary.util;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileChannel.MapMode;
-import java.util.Objects;
-
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.concurrent.atomic.AtomicReference;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import sun.misc.Unsafe;
 
 public class FileChannelDirectInputStream extends ByteBufferInputStream {
     private final FileChannel channel;
@@ -50,24 +57,67 @@ public class FileChannelDirectInputStream extends ByteBufferInputStream {
             }
         }
     }
+
+    private static final @MonotonicNonNull MethodHandle INVOKE_CLEANER;
+    private static final @MonotonicNonNull Object THE_UNSAFE;
+
+    // see https://stackoverflow.com/a/19447758/11098
+    static {
+        final AtomicReference<@Nullable MethodHandle> cleaner = new AtomicReference<>(null);
+        final AtomicReference<@Nullable Object> unsafe = new AtomicReference<>(null);
+        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+            Class<?> unsafeClass;
+            try {
+                unsafeClass = Class.forName("sun.misc.Unsafe");
+            } catch(Exception ex) {
+                // jdk.internal.misc.Unsafe doesn't yet have an invokeCleaner() method,
+                // but that method should be added if sun.misc.Unsafe is removed.
+                try {
+                    unsafeClass = Class.forName("jdk.internal.misc.Unsafe");
+                } catch (Exception e) {
+                    unsafeClass = null;
+                    System.err.println(FileChannelDirectInputStream.class.getName() + ": cannot locate unsafe class :" + e);
+                }
+            }
+            if (unsafeClass == null) {
+                System.err.println(FileChannelDirectInputStream.class.getName() + ": cannot locate unsafe class");
+                return null;
+            }
+            try {
+                cleaner.set(MethodHandles.lookup().findVirtual(
+                    unsafeClass, "invokeCleaner",
+                    MethodType.methodType(void.class, ByteBuffer.class)));
+                
+                Field theUnsafeField = unsafeClass.getDeclaredField("theUnsafe");
+                theUnsafeField.setAccessible(true);
+                unsafe.set(theUnsafeField.get(null));
+                return null;
+            }
+            catch (NoSuchMethodException | IllegalAccessException | NoSuchFieldException e) {
+                System.err.println(FileChannelDirectInputStream.class.getName() + ": cannot locate unsafe instance or invokeCleaner: " + e);
+                cleaner.set(null);
+                unsafe.set(null);
+                return null;
+            }
+        });
+        INVOKE_CLEANER = cleaner.get();
+        THE_UNSAFE = unsafe.get();
+    }
     // from: http://stackoverflow.com/a/19447758/11098
     private static void closeDirectBuffer(@Nullable ByteBuffer cb) {
         if (cb==null || !cb.isDirect()) return;
-
-        // we could use this type cast and call functions without reflection code,
-        // but static import from sun.* package is risky for non-SUN virtual machine.
-        //try { ((sun.nio.ch.DirectBuffer)cb).cleaner().clean(); } catch (Exception ex) { }
-        try {
-            Method cleaner = cb.getClass().getMethod("cleaner");
-            cleaner.setAccessible(true);
-            Method clean = Class.forName("sun.misc.Cleaner").getMethod("clean");
-            clean.setAccessible(true);
-            Object param = cleaner.invoke(cb);
-            if (param != null) {
-                clean.invoke(param);   
+        if (INVOKE_CLEANER != null && THE_UNSAFE != null) {
+            try {
+                INVOKE_CLEANER.invoke(THE_UNSAFE, cb);
+            } catch (Throwable e) {
+                System.err.println(FileChannelDirectInputStream.class.getName() + ": error cleaning: " + e);
             }
-        } catch(Exception ex) { }
-        cb = null;
+        }
+        else {
+            // we could not find a cleaner, so as a fall-back we are gonna request a gc
+            cb = null;
+            System.gc();
+        }
     }
 
 }

--- a/src/main/java/io/usethesource/vallang/io/binary/util/FileChannelDirectInputStream.java
+++ b/src/main/java/io/usethesource/vallang/io/binary/util/FileChannelDirectInputStream.java
@@ -61,8 +61,8 @@ public class FileChannelDirectInputStream extends ByteBufferInputStream {
 
     // see https://stackoverflow.com/a/19447758/11098
     static {
-        final AtomicReference<@Nullable MethodHandle> cleaner = new AtomicReference<>(null);
-        final AtomicReference<@Nullable Object> unsafe = new AtomicReference<>(null);
+        final AtomicReference<@Nullable MethodHandle> cleaner = new AtomicReference<>();
+        final AtomicReference<@Nullable Object> unsafe = new AtomicReference<>();
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             Class<?> unsafeClass;
             try {
@@ -86,9 +86,12 @@ public class FileChannelDirectInputStream extends ByteBufferInputStream {
                     unsafeClass, "invokeCleaner",
                     MethodType.methodType(void.class, ByteBuffer.class)));
                 
+
                 Field theUnsafeField = unsafeClass.getDeclaredField("theUnsafe");
                 theUnsafeField.setAccessible(true);
-                unsafe.set(theUnsafeField.get(null));
+                @SuppressWarnings("nullness") // CF marks .get as not accepting null, since the api is
+                Object unsafeValue = theUnsafeField.get(null);
+                unsafe.set(unsafeValue);
                 return null;
             }
             catch (NoSuchMethodException | IllegalAccessException | NoSuchFieldException e) {


### PR DESCRIPTION
This gets rid of the warning in issue #119 but migrating to java modules in the future would still be prefered, as that would drop the requirement for reflection