### PR TITLE
Rewrote the caches introduce for the hashconsing of types

### DIFF
--- a/src/main/java/io/usethesource/vallang/type/TypeFactory.java
+++ b/src/main/java/io/usethesource/vallang/type/TypeFactory.java
@@ -62,7 +62,7 @@ public class TypeFactory {
 	/**
 	 * Caches all types to implement canonicalization
 	 */
-	private final HashConsingMap<Type> fCache = new WeakReferenceHashConsingMap<>(8*1024, (int)TimeUnit.MINUTES.toSeconds(30));
+	private final HashConsingMap<Type> fCache = new WeakReferenceHashConsingMap<>(32*1024, (int)TimeUnit.MINUTES.toSeconds(30));
     private volatile @MonotonicNonNull TypeValues typeValues; // lazy initialize
     
 	private static class InstanceHolder {


### PR DESCRIPTION
The implementation introduced in #131 was found to cause a slowdown in heavy usage. The main problem was that the gets would schedule cleanup tasks in the hot path. This is normally wise, to avoid a cache getting overly full. But in our case we just want a cache that after a while (30min) starts to clean up, so if the cleanup happens infrequently, thats fine.

This new implementation combines part of the old strategy (introduced in #14) but it also keeps the logic of #131 to have a hot cache for entries that are requested quite often. Since the hot cache is fine to drop some entries in case of a hash collision, it can be implemented without collision resolution. So the most common entries will be a single lookup in an array.

I've done some benchmarks, and in the case of an import that took 16s, we would spend 1s in this `get` function. This PR brings that back to 200ms.

This also finally fixes #135 