### PR TITLE
Avoided self loop in case there is already an self edge to begin with

### DIFF
--- a/src/main/java/io/usethesource/vallang/impl/persistent/PersistentHashIndexedBinaryRelation.java
+++ b/src/main/java/io/usethesource/vallang/impl/persistent/PersistentHashIndexedBinaryRelation.java
@@ -644,9 +644,15 @@ public final class PersistentHashIndexedBinaryRelation implements ISet, IRelatio
       else {
         throw new IllegalArgumentException("Unexpected map entry");
       }
+      // to avoid recalculating `lhs` next time we see it, we mark it as done.
+      // so that the next time we come across if on the rhs, we know the range is
+      // already the transitive closure.
+      // We add it before we've done it, just to avoid scheduling
+      // <a,a> when it occurs during the depth scan for lhs.
+      done.add(lhs); 
       IValue rhs;
       while ((rhs = todo.poll()) != null) {
-        if (rhs.equals(lhs)) {
+        if (lhs == rhs) {
           // no need to handle <a,a>
           continue;
         }
@@ -657,10 +663,6 @@ public final class PersistentHashIndexedBinaryRelation implements ISet, IRelatio
           }
         }
       }
-      // `lhs` is now completly calculated, so if we come across it, you don't 
-      // have to go into depth for it anymore, the range of lhs is already the
-      // transitive closure
-      done.add(lhs); 
     }
     return result;
   }

--- a/src/main/java/io/usethesource/vallang/impl/persistent/PersistentHashIndexedBinaryRelation.java
+++ b/src/main/java/io/usethesource/vallang/impl/persistent/PersistentHashIndexedBinaryRelation.java
@@ -634,7 +634,7 @@ public final class PersistentHashIndexedBinaryRelation implements ISet, IRelatio
       final IValue lhs = focus.getKey();
       final Object values =focus.getValue();
 
-      todo.clear();
+      assert todo.isEmpty();
       if (values instanceof IValue) {
         todo.push((IValue)values);
       }

--- a/src/main/java/io/usethesource/vallang/impl/persistent/PersistentHashIndexedBinaryRelation.java
+++ b/src/main/java/io/usethesource/vallang/impl/persistent/PersistentHashIndexedBinaryRelation.java
@@ -644,11 +644,12 @@ public final class PersistentHashIndexedBinaryRelation implements ISet, IRelatio
       else {
         throw new IllegalArgumentException("Unexpected map entry");
       }
-      // we mark ourselves as done before we did it, 
-      // so we don't do the <a,a> that causes an extra round
-      done.add(lhs); 
       IValue rhs;
       while ((rhs = todo.poll()) != null) {
+        if (rhs.equals(lhs)) {
+          // no need to handle <a,a>
+          continue;
+        }
         boolean rhsDone = done.contains(rhs);
         for (IValue composed : result.get(rhs)) {
           if (result.__insert(lhs, composed) && !rhsDone) {
@@ -656,6 +657,10 @@ public final class PersistentHashIndexedBinaryRelation implements ISet, IRelatio
           }
         }
       }
+      // `lhs` is now completly calculated, so if we come across it, you don't 
+      // have to go into depth for it anymore, the range of lhs is already the
+      // transitive closure
+      done.add(lhs); 
     }
     return result;
   }


### PR DESCRIPTION
This is a small perf fix for the case that a graph contains a lot of self refering edges to begin with. This saves of a whole lot of steps in that case.

Also realized the adding to `done` can be placed after it's done, to better align with where you would expect this to happen.