### PR TITLE
Solve perf issue serializing large collections

### DIFF
--- a/src/test/java/io/usethesource/vallang/io/reference/ReferenceStructuredIValueVisitor.java
+++ b/src/test/java/io/usethesource/vallang/io/reference/ReferenceStructuredIValueVisitor.java
@@ -75,13 +75,8 @@ public class ReferenceStructuredIValueVisitor {
             @Override
             public Void visitSet(ISet o) throws E {
                 if (visit.enterSet(o, o.size())) {
-                    List<IValue> reversedSet = new ArrayList<>();
-                    for (IValue v:  o) {
-                        reversedSet.add(v);
-                    }
-                    ListIterator<IValue> li = reversedSet.listIterator(reversedSet.size());
-                    while (li.hasPrevious()) {
-                        li.previous().accept(this);
+                    for (IValue v: o) {
+                        v.accept(this);
                     }
                     visit.leaveSet(o);
                 }
@@ -91,15 +86,11 @@ public class ReferenceStructuredIValueVisitor {
             @Override
             public Void visitMap(IMap o) throws E {
                 if (visit.enterMap(o, o.size())) {
-                    List<IValue> reversedMap = new ArrayList<>();
-                    for (IValue v:  o) {
-                        reversedMap.add(v);
-                    }
-                    ListIterator<IValue> li = reversedMap.listIterator(reversedMap.size());
-                    while (li.hasPrevious()) {
-                        IValue k = li.previous();
-                        k.accept(this);
-                        o.get(k).accept(this);
+                    var entries = o.entryIterator();
+                    while (entries.hasNext()) {
+                        var entry = entries.next();
+                        entry.getKey().accept(this);
+                        entry.getValue().accept(this);
                     }
                     visit.leaveMap(o);
                 }


### PR DESCRIPTION
We have a stackless structured visitor that doesn't require large call stacks to deal with deeply nested ASTs.

While this worked great for deep ASTs, it doesn't work great for big flat collections (aka wide).

Big collections would require the same amount of memory, just to prepare the stack with all the entries. Now we have iterating entries on the stack, that can be "returned to" multiple times.

Note, I had to change the tests, as they assumed reverse orders for sets & maps in the visitor, which was not an actual requirement.