### PR TITLE
Fix bug where a large file (>1GiB) would cause a int overflow

### DIFF
--- a/src/main/java/io/usethesource/vallang/io/binary/util/DirectZstdInputStream.java
+++ b/src/main/java/io/usethesource/vallang/io/binary/util/DirectZstdInputStream.java
@@ -28,7 +28,11 @@ public class DirectZstdInputStream extends ByteBufferInputStream {
 
     private static ByteBuffer constructDecompressedBuffer(ByteBufferInputStream oriStream) {
         int compressedSize = oriStream.getByteBuffer().remaining();
-        ByteBuffer result = DirectByteBufferCache.getInstance().get(Math.min(compressedSize * 2, ZstdDirectBufferDecompressingStream.recommendedTargetBufferSize()));
+        int bufferSize = ZstdDirectBufferDecompressingStream.recommendedTargetBufferSize();
+        if (bufferSize > compressedSize) {
+            bufferSize = Math.min(compressedSize * 2, bufferSize);
+        }
+        ByteBuffer result = DirectByteBufferCache.getInstance().get(bufferSize);
         result.limit(0); // delay compression for first read
         return result;
     }


### PR DESCRIPTION
The reasons was to avoid large buffers getting allocated for small files, but that hurt big files in the end.

It was only triggered with files bigger than `(1<<31)/2`. So any file bigger than 1073741824 bytes, or 1024 MiB, aka 1 GiB