### PR TITLE
added proper alias checks to the match implementations of parametrized types

### DIFF
--- a/src/main/java/io/usethesource/vallang/type/AbstractDataType.java
+++ b/src/main/java/io/usethesource/vallang/type/AbstractDataType.java
@@ -428,7 +428,7 @@ import io.usethesource.vallang.type.TypeFactory.TypeValues;
             return false;
         }
 
-        if (matched.isAbstractData() || matched.isBottom()) {
+        if (matched.isAbstractData() || (matched.isAliased() && matched.getAliased().isAbstractData()) || matched.isBottom()) {
             return getTypeParameters().match(matched.getTypeParameters(), bindings);
         }
 

--- a/src/main/java/io/usethesource/vallang/type/ListType.java
+++ b/src/main/java/io/usethesource/vallang/type/ListType.java
@@ -286,12 +286,11 @@ import io.usethesource.vallang.type.TypeFactory.TypeValues;
 	}
 
 	@Override
-	public boolean match(Type matched, Map<Type, Type> bindings)
-			throws FactTypeUseException {
+	public boolean match(Type matched, Map<Type, Type> bindings) throws FactTypeUseException {
 		if (!super.match(matched, bindings)) {
 			return false;
 		}
-		else if (matched.isList() || matched.isBottom()) {
+		else if (matched.isList() || (matched.isAliased() && matched.getAliased().isList()) || matched.isBottom()) {
 			return getElementType().match(matched.getElementType(), bindings);
 		}
 

--- a/src/main/java/io/usethesource/vallang/type/MapType.java
+++ b/src/main/java/io/usethesource/vallang/type/MapType.java
@@ -244,7 +244,7 @@ import io.usethesource.vallang.type.TypeFactory.TypeValues;
           return false;
         }
 
-        if (matched.isMap() || matched.isBottom()) {
+        if (matched.isMap() || (matched.isAliased() && matched.getAliased().isMap()) ||  matched.isBottom()) {
 				  return getKeyType().match(matched.getKeyType(), bindings)
           && getValueType().match(matched.getValueType(), bindings);
         }

--- a/src/main/java/io/usethesource/vallang/type/SetType.java
+++ b/src/main/java/io/usethesource/vallang/type/SetType.java
@@ -289,7 +289,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 		if (!super.match(matched, bindings)) {
 			return false;
 		}
-		else if (matched.isSet() || matched.isBottom()) {
+		else if (matched.isSet() || (matched.isAliased() && matched.getAliased().isSet()) || matched.isBottom()) {
 			return getElementType().match(matched.getElementType(), bindings);
 		}
 

--- a/src/main/java/io/usethesource/vallang/type/TupleType.java
+++ b/src/main/java/io/usethesource/vallang/type/TupleType.java
@@ -419,7 +419,7 @@ import io.usethesource.vallang.type.TypeFactory.TypeValues;
             return false;
         }
 
-        if (matched.isTuple() || matched.isBottom()) {
+        if (matched.isTuple() || (matched.isAliased() && matched.getAliased().isTuple()) || matched.isBottom()) {
             for (int i = getArity() - 1; i >= 0; i--) {
                 if (!getFieldType(i).match(matched.getFieldType(i), bindings)) {
                     return false;


### PR DESCRIPTION
This fixes usethesource/rascal#1812
