### PR TITLE
Increase performance of IString Readers for the `read(CharBuffer)` overload

### DIFF
--- a/src/main/java/io/usethesource/vallang/impl/primitive/StringValue.java
+++ b/src/main/java/io/usethesource/vallang/impl/primitive/StringValue.java
@@ -1022,7 +1022,12 @@ import io.usethesource.vallang.type.TypeFactory;
                     if (off < 0 || len < 0 || len > cbuf.length + off) {
                         throw new IndexOutOfBoundsException();
                     }
-                    var target = CharBuffer.wrap(cbuf, off, len);
+                    return read(CharBuffer.wrap(cbuf, off, len));
+                }
+
+                @Override
+                public int read(CharBuffer target) throws IOException {
+                    int start = target.position();
                     while (target.hasRemaining()) {
                         var actualBuffer = getBuffer();
                         if (!actualBuffer.hasRemaining()) {
@@ -1030,7 +1035,7 @@ import io.usethesource.vallang.type.TypeFactory;
                         }
                         actualBuffer.read(target);
                     }
-                    return target.position() == off ? -1 : (len - target.remaining());
+                    return target.position() == start ? -1 : target.position() - start;
                 }
 
                 @Override

--- a/src/test/java/io/usethesource/vallang/basic/BasicValueSmokeTest.java
+++ b/src/test/java/io/usethesource/vallang/basic/BasicValueSmokeTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.net.URISyntaxException;
+import java.nio.CharBuffer;
 import java.util.PrimitiveIterator.OfInt;
 import java.util.Random;
 import java.util.regex.Pattern;
@@ -402,14 +403,29 @@ public final class BasicValueSmokeTest {
 
     }
 
+    private String readerCharBufferToString(IString a) {
+        var buf = CharBuffer.allocate(a.length() * 2);
+        try (var r = a.asReader()) {
+            while (r.read(buf) != -1) ;
+            buf.flip();
+            return buf.toString();
+        } catch (IOException e) {
+            fail("IString::asReader failed", e);
+            return "";
+        }
+    }
+
 
     private void assertEqualWriteAndRead(IString one, IString two) {
+        assertEquals(one.length(), two.length(), "IString::length should be equal");
         assertEquals(one.getValue(), writerToString(one), "IString::write should be the same as getValue");
         assertEquals(one.getValue(), readerToString(one), "IString::asReader should be the same as getValue");
         assertEquals(writerToString(one), writerToString(two), "IString::write had different results");
         assertEquals(readerToString(one), readerToString(two), "IString::asReader had different results");
         assertEquals(one.getValue(), readerSlowly(one), "IString::asReader had different results depending on buffer size");
         assertEquals(two.getValue(), readerSlowly(two), "IString::asReader had different results depending on buffer size");
+        assertEquals(one.getValue(), readerCharBufferToString(one), "IString::asReader had different results when using char buffer read");
+        assertEquals(two.getValue(), readerCharBufferToString(two), "IString::asReader had different results when using char buffer read");
     }
 
     private void assertEqualCharAt(IString one, IString two) {


### PR DESCRIPTION
Since we internally use an iterator over char buffers, lets use that if possible.