### PR TITLE
Added support for writing formfeed and backspace escaped characters

### DIFF
--- a/src/main/java/io/usethesource/vallang/io/StandardTextWriter.java
+++ b/src/main/java/io/usethesource/vallang/io/StandardTextWriter.java
@@ -542,6 +542,14 @@ public class StandardTextWriter implements IValueTextWriter {
                         append('\\');
                         append('t');
                         break;
+                    case '\f':
+                        append('\\');
+                        append('f');
+                        break;
+                    case '\b':
+                        append('\\');
+                        append('b');
+                        break;
                     case ' ':
                         // needed because other space chars will be escaped in the default branch
                         append(' ');


### PR DESCRIPTION
Formfeed and backspace support was missing from StandardTextWriter.visitString.