### PR TITLE
removed implicit changes to RandomTypeConfig during the recursive random type generator. 

### DIFF
--- a/src/main/java/io/usethesource/vallang/type/AbstractDataType.java
+++ b/src/main/java/io/usethesource/vallang/type/AbstractDataType.java
@@ -14,6 +14,7 @@ package io.usethesource.vallang.type;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -133,9 +134,9 @@ import io.usethesource.vallang.type.TypeFactory.TypeValues;
         }
 
         @Override
-        public Type randomInstance(Function<RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd) {
+        public Type randomInstance(BiFunction<TypeStore, RandomTypesConfig, Type> next, TypeStore store, RandomTypesConfig rnd) {
             if (!rnd.isWithRandomAbstractDatatypes()) {
-                return next.apply(rnd);
+                return next.apply(store, rnd);
             }
 
             if (rnd.nextBoolean()) {

--- a/src/main/java/io/usethesource/vallang/type/AbstractDataType.java
+++ b/src/main/java/io/usethesource/vallang/type/AbstractDataType.java
@@ -155,14 +155,14 @@ import io.usethesource.vallang.type.TypeFactory.TypeValues;
             } while (store.lookupAbstractDataType(adtName) != null);
 
             if (rnd.nextBoolean()) {
-                Type param1 = new ParameterType.Info(symbols()).randomInstance(next, store, rnd.withTypeParameters());
+                Type param1 = new ParameterType.Info(symbols()).randomInstance(next, store, rnd);
 
                 if (rnd.nextBoolean()) {
                     // first declare the open type:
                     adt = tf().abstractDataTypeFromTuple(store, adtName, tf().tupleType(param1));
                 }
                 else {
-                    Type param2 = new ParameterType.Info(symbols()).randomInstance(next, store, rnd.withTypeParameters());
+                    Type param2 = new ParameterType.Info(symbols()).randomInstance(next, store, rnd);
 
                     // first declare the open type
                     adt = tf().abstractDataTypeFromTuple(store, adtName, tf().tupleType(param1, param2));

--- a/src/main/java/io/usethesource/vallang/type/AbstractDataType.java
+++ b/src/main/java/io/usethesource/vallang/type/AbstractDataType.java
@@ -155,7 +155,7 @@ import io.usethesource.vallang.type.TypeFactory.TypeValues;
                 adtName = randomLabel(rnd);
             } while (store.lookupAbstractDataType(adtName) != null);
 
-            if (rnd.nextBoolean()) {
+            if (rnd.isWithTypeParameters() && rnd.nextBoolean()) {
                 Type param1 = new ParameterType.Info(symbols()).randomInstance(next, store, rnd);
 
                 if (rnd.nextBoolean()) {
@@ -164,7 +164,6 @@ import io.usethesource.vallang.type.TypeFactory.TypeValues;
                 }
                 else {
                     Type param2 = new ParameterType.Info(symbols()).randomInstance(next, store, rnd);
-
                     // first declare the open type
                     adt = tf().abstractDataTypeFromTuple(store, adtName, tf().tupleType(param1, param2));
                 }
@@ -389,9 +388,6 @@ import io.usethesource.vallang.type.TypeFactory.TypeValues;
         }
 
         TypeStore store = new TypeStore();
-
-        // TODO: find out why we had this call
-        // store.declareAbstractDataType(this);
 
         // Here it is important _not_ to reuse TupleType.instantiate, since
         // that has a normalizing feature to `void` if one of the parameters

--- a/src/main/java/io/usethesource/vallang/type/AliasType.java
+++ b/src/main/java/io/usethesource/vallang/type/AliasType.java
@@ -16,6 +16,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -101,7 +102,7 @@ import io.usethesource.vallang.type.TypeFactory.TypeValues;
         }
 
         @Override
-        public Type randomInstance(Function<RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd) {
+        public Type randomInstance(BiFunction<TypeStore, RandomTypesConfig, Type> next, TypeStore store, RandomTypesConfig rnd) {
             // we don't generate aliases because we also never reify them
             if (!rnd.isWithAliases()) {
                 return tf().randomType(store, rnd);

--- a/src/main/java/io/usethesource/vallang/type/BoolType.java
+++ b/src/main/java/io/usethesource/vallang/type/BoolType.java
@@ -15,6 +15,7 @@ package io.usethesource.vallang.type;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import io.usethesource.vallang.IConstructor;
 import io.usethesource.vallang.IValue;
@@ -49,7 +50,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
         }
 
         @Override
-        public Type randomInstance(Function<RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd) {
+        public Type randomInstance(BiFunction<TypeStore, RandomTypesConfig, Type> next, TypeStore store, RandomTypesConfig rnd) {
             return tf().boolType();
         }
     }

--- a/src/main/java/io/usethesource/vallang/type/ConstructorType.java
+++ b/src/main/java/io/usethesource/vallang/type/ConstructorType.java
@@ -13,6 +13,7 @@ package io.usethesource.vallang.type;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -165,7 +166,7 @@ import io.usethesource.vallang.type.TypeFactory.TypeValues;
         }
 
         @Override
-        public Type randomInstance(Function<RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd) {
+        public Type randomInstance(BiFunction<TypeStore, RandomTypesConfig, Type> next, TypeStore store, RandomTypesConfig rnd) {
             // constructors should not be random types of values (a value never has a constructor type)
             return new AbstractDataType.Info(symbols()).randomInstance(next, store, rnd);
         }

--- a/src/main/java/io/usethesource/vallang/type/DateTimeType.java
+++ b/src/main/java/io/usethesource/vallang/type/DateTimeType.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import io.usethesource.vallang.IConstructor;
@@ -59,7 +60,7 @@ public class DateTimeType extends DefaultSubtypeOfValue {
         }
 
         @Override
-        public Type randomInstance(Function<RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd) {
+        public Type randomInstance(BiFunction<TypeStore, RandomTypesConfig, Type> next, TypeStore store, RandomTypesConfig rnd) {
             return tf().dateTimeType();
         }
     }

--- a/src/main/java/io/usethesource/vallang/type/FunctionType.java
+++ b/src/main/java/io/usethesource/vallang/type/FunctionType.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -93,7 +94,7 @@ public class FunctionType extends DefaultSubtypeOfValue {
         }
 
         @Override
-        public Type randomInstance(Function<RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd) {
+        public Type randomInstance(BiFunction<TypeStore, RandomTypesConfig, Type> next, TypeStore store, RandomTypesConfig rnd) {
             // TODO: as we do not have IFunction yet in vallang, we should not generate random
             // function types either. It will lead to exceptions otherwise.
             // return TF.functionType(next.get(), (TupleType) TF.tupleType(next.get()), (TupleType) TF.tupleEmpty());

--- a/src/main/java/io/usethesource/vallang/type/IntegerType.java
+++ b/src/main/java/io/usethesource/vallang/type/IntegerType.java
@@ -15,6 +15,7 @@ package io.usethesource.vallang.type;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import static io.usethesource.vallang.random.util.RandomUtil.oneEvery;
 
@@ -52,7 +53,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
         }
 
         @Override
-        public Type randomInstance(Function<RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd) {
+        public Type randomInstance(BiFunction<TypeStore, RandomTypesConfig, Type> next, TypeStore store, RandomTypesConfig rnd) {
             return tf().integerType();
         }
     }

--- a/src/main/java/io/usethesource/vallang/type/ListType.java
+++ b/src/main/java/io/usethesource/vallang/type/ListType.java
@@ -17,6 +17,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -91,8 +92,8 @@ import io.usethesource.vallang.type.TypeFactory.TypeValues;
         }
 
         @Override
-        public Type randomInstance(Function<RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd) {
-            return tf().listType(next.apply(rnd));
+        public Type randomInstance(BiFunction<TypeStore, RandomTypesConfig, Type> next, TypeStore store, RandomTypesConfig rnd) {
+            return tf().listType(next.apply(store, rnd));
         }
 
         @Override

--- a/src/main/java/io/usethesource/vallang/type/MapType.java
+++ b/src/main/java/io/usethesource/vallang/type/MapType.java
@@ -16,6 +16,7 @@ package io.usethesource.vallang.type;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -95,12 +96,12 @@ import io.usethesource.vallang.type.TypeFactory.TypeValues;
         }
 
         @Override
-        public Type randomInstance(Function<RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd) {
+        public Type randomInstance(BiFunction<TypeStore, RandomTypesConfig, Type> next, TypeStore store, RandomTypesConfig rnd) {
             if (rnd.isWithMapFieldNames() && rnd.nextBoolean()) {
-                return tf().mapType(next.apply(rnd), randomLabel(rnd), next.apply(rnd), randomLabel(rnd));
+                return tf().mapType(next.apply(store, rnd), randomLabel(rnd), next.apply(store, rnd), randomLabel(rnd));
             }
             else {
-                return tf().mapType(next.apply(rnd), next.apply(rnd));
+                return tf().mapType(next.apply(store, rnd), next.apply(store, rnd));
             }
         }
     }

--- a/src/main/java/io/usethesource/vallang/type/MapType.java
+++ b/src/main/java/io/usethesource/vallang/type/MapType.java
@@ -100,7 +100,7 @@ import io.usethesource.vallang.type.TypeFactory.TypeValues;
                 return tf().mapType(next.apply(rnd), randomLabel(rnd), next.apply(rnd), randomLabel(rnd));
             }
             else {
-                return tf().mapType(next.apply(rnd.withMapFieldNames()), next.apply(rnd.withMapFieldNames()));
+                return tf().mapType(next.apply(rnd), next.apply(rnd));
             }
         }
     }

--- a/src/main/java/io/usethesource/vallang/type/NodeType.java
+++ b/src/main/java/io/usethesource/vallang/type/NodeType.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -57,7 +58,7 @@ class NodeType extends DefaultSubtypeOfValue {
         }
 
         @Override
-        public Type randomInstance(Function<RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd) {
+        public Type randomInstance(BiFunction<TypeStore, RandomTypesConfig, Type> next, TypeStore store, RandomTypesConfig rnd) {
             return tf().nodeType();
         }
     }

--- a/src/main/java/io/usethesource/vallang/type/NumberType.java
+++ b/src/main/java/io/usethesource/vallang/type/NumberType.java
@@ -15,6 +15,7 @@ package io.usethesource.vallang.type;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -53,7 +54,7 @@ import io.usethesource.vallang.type.TypeFactory.TypeValues;
         }
 
         @Override
-        public Type randomInstance(Function<RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd) {
+        public Type randomInstance(BiFunction<TypeStore, RandomTypesConfig, Type> next, TypeStore store, RandomTypesConfig rnd) {
             return tf().numberType();
         }
     }

--- a/src/main/java/io/usethesource/vallang/type/ParameterType.java
+++ b/src/main/java/io/usethesource/vallang/type/ParameterType.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -65,12 +66,12 @@ import io.usethesource.vallang.type.TypeFactory.TypeValues;
         }
 
         @Override
-        public Type randomInstance(Function<RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd) {
+        public Type randomInstance(BiFunction<TypeStore, RandomTypesConfig, Type> next, TypeStore store, RandomTypesConfig rnd) {
             if (rnd.isWithTypeParameters()) {
                 return tf().parameterType(randomLabel(rnd));
             }
 
-            return next.apply(rnd);
+            return next.apply(store, rnd);
         }
 
         @Override

--- a/src/main/java/io/usethesource/vallang/type/RationalType.java
+++ b/src/main/java/io/usethesource/vallang/type/RationalType.java
@@ -15,6 +15,7 @@ package io.usethesource.vallang.type;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import io.usethesource.vallang.IConstructor;
 import io.usethesource.vallang.IValue;
@@ -50,7 +51,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
         }
 
         @Override
-        public Type randomInstance(Function<RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd) {
+        public Type randomInstance(BiFunction<TypeStore, RandomTypesConfig, Type> next, TypeStore store, RandomTypesConfig rnd) {
             return tf().rationalType();
         }
     }

--- a/src/main/java/io/usethesource/vallang/type/RealType.java
+++ b/src/main/java/io/usethesource/vallang/type/RealType.java
@@ -17,6 +17,7 @@ import java.math.BigDecimal;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import io.usethesource.vallang.IConstructor;
 import io.usethesource.vallang.IValue;
@@ -53,7 +54,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
         }
 
         @Override
-        public Type randomInstance(Function<RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd) {
+        public Type randomInstance(BiFunction<TypeStore, RandomTypesConfig, Type> next, TypeStore store, RandomTypesConfig rnd) {
             return tf().realType();
         }
     }

--- a/src/main/java/io/usethesource/vallang/type/SetType.java
+++ b/src/main/java/io/usethesource/vallang/type/SetType.java
@@ -58,7 +58,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
         @Override
         public Type randomInstance(Function<RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd) {
-            return tf().setType(next.apply(rnd.withTupleFieldNames().withMapFieldNames()));
+            return tf().setType(next.apply(rnd));
         }
 
         @Override

--- a/src/main/java/io/usethesource/vallang/type/SetType.java
+++ b/src/main/java/io/usethesource/vallang/type/SetType.java
@@ -17,6 +17,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -57,8 +58,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
         }
 
         @Override
-        public Type randomInstance(Function<RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd) {
-            return tf().setType(next.apply(rnd));
+        public Type randomInstance(BiFunction<TypeStore, RandomTypesConfig, Type> next, TypeStore store, RandomTypesConfig rnd) {
+            return tf().setType(next.apply(store, rnd));
         }
 
         @Override

--- a/src/main/java/io/usethesource/vallang/type/SourceLocationType.java
+++ b/src/main/java/io/usethesource/vallang/type/SourceLocationType.java
@@ -16,6 +16,7 @@ import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import static io.usethesource.vallang.random.util.RandomUtil.oneEvery;
 
@@ -55,7 +56,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
         }
 
         @Override
-        public Type randomInstance(Function<RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd) {
+        public Type randomInstance(BiFunction<TypeStore, RandomTypesConfig, Type> next, TypeStore store, RandomTypesConfig rnd) {
             return tf().sourceLocationType();
         }
     }

--- a/src/main/java/io/usethesource/vallang/type/StringType.java
+++ b/src/main/java/io/usethesource/vallang/type/StringType.java
@@ -15,6 +15,7 @@ package io.usethesource.vallang.type;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import io.usethesource.vallang.IConstructor;
 import io.usethesource.vallang.IValue;
@@ -51,7 +52,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
         }
 
         @Override
-        public Type randomInstance(Function<RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd) {
+        public Type randomInstance(BiFunction<TypeStore, RandomTypesConfig, Type> next, TypeStore store, RandomTypesConfig rnd) {
             return tf().stringType();
         }
     }

--- a/src/main/java/io/usethesource/vallang/type/TupleType.java
+++ b/src/main/java/io/usethesource/vallang/type/TupleType.java
@@ -97,8 +97,6 @@ import io.usethesource.vallang.type.TypeFactory.TypeValues;
         /*package*/ Type randomInstance(Function<RandomTypesConfig,Type> next, RandomTypesConfig rnd, int arity) {
             Type[] types = new Type[arity];
 
-            rnd = rnd.withMapFieldNames();
-
             for (int i = 0; i < arity; i++) {
                 while ((types[i] = next.apply(rnd)).isBottom()) {} // tuples can not have empty fields
             }

--- a/src/main/java/io/usethesource/vallang/type/TupleType.java
+++ b/src/main/java/io/usethesource/vallang/type/TupleType.java
@@ -15,6 +15,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -89,16 +90,16 @@ import io.usethesource.vallang.type.TypeFactory.TypeValues;
         }
 
         @Override
-        public Type randomInstance(Function<RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd) {
-            return randomInstance(next, rnd, rnd.nextInt(rnd.getMaxDepth() + 1));
+        public Type randomInstance(BiFunction<TypeStore, RandomTypesConfig, Type> next, TypeStore store, RandomTypesConfig rnd) {
+            return randomInstance(next, store, rnd, rnd.nextInt(rnd.getMaxDepth() + 1));
         }
 
         @SuppressWarnings("deprecation")
-        /*package*/ Type randomInstance(Function<RandomTypesConfig,Type> next, RandomTypesConfig rnd, int arity) {
+        /*package*/ Type randomInstance(BiFunction<TypeStore,RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd, int arity) {
             Type[] types = new Type[arity];
 
             for (int i = 0; i < arity; i++) {
-                while ((types[i] = next.apply(rnd)).isBottom()) {} // tuples can not have empty fields
+                while ((types[i] = next.apply(store, rnd)).isBottom()) {} // tuples can not have empty fields
             }
 
             if (!rnd.isWithTupleFieldNames() || rnd.nextBoolean()) {

--- a/src/main/java/io/usethesource/vallang/type/TypeFactory.java
+++ b/src/main/java/io/usethesource/vallang/type/TypeFactory.java
@@ -30,6 +30,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -82,21 +83,23 @@ public class TypeFactory {
         return cachedTypeValues().randomType(store, config);
     }
 
-    public Type randomADTType(TypeStore store, RandomTypesConfig config) {
-        assert config.isWithRandomAbstractDatatypes();
+    // public Type randomADTType(TypeStore store, RandomTypesConfig config) {
+    //     assert config.isWithRandomAbstractDatatypes();
 
-        synchronized (this) {
-            var tv = cachedTypeValues();
-            Type adt = null;
+    //     synchronized (this) {
+    //         var tv = cachedTypeValues();
+    //         Type adt = null;
 
-            // TODO this is not very efficient. Temporary workaround due to visibility issues.
-            do {
-                adt = tv.randomType(store, config);
-            } while (!(adt instanceof AbstractDataType));
+    //         // TODO this is not very efficient. Temporary workaround due to visibility issues.
+    //         do {
+    //             // this seems wrong. There could be side-effects in the type store
+    //             // that break later contracts.
+    //             adt = tv.randomType(store, config);
+    //         } while (!(adt instanceof AbstractDataType));
 
-            return adt;
-        }
-    }
+    //         return adt;
+    //     }
+    // }
 
     public Type randomType(TypeStore typeStore) {
         return cachedTypeValues().randomType(typeStore, RandomTypesConfig.defaultConfig(new Random()));
@@ -861,7 +864,7 @@ public class TypeFactory {
             return false;
         }
 
-        public abstract Type randomInstance(Function<RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd);
+        public abstract Type randomInstance(BiFunction<TypeStore, RandomTypesConfig, Type> next, TypeStore store, RandomTypesConfig rnd);
 
         public IConstructor toSymbol(Type type, IValueFactory vf, TypeStore store, ISetWriter grammar, Set<IConstructor> done) {
             // this will work for all nullary type symbols with only one constructor type
@@ -878,12 +881,12 @@ public class TypeFactory {
             return "x" + new BigInteger(32, rnd.getRandom()).toString(32);
         }
 
-        public Type randomTuple(Function<RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd) {
+        public Type randomTuple(BiFunction<TypeStore, RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd) {
             return new TupleType.Info(cachedSymbols).randomInstance(next, store, rnd);
         }
 
-        public Type randomTuple(Function<RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd, int arity) {
-            return new TupleType.Info(cachedSymbols).randomInstance(next, rnd, arity);
+        public Type randomTuple(BiFunction<TypeStore, RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd, int arity) {
+            return new TupleType.Info(cachedSymbols).randomInstance(next, store, rnd, arity);
         }
     }
 
@@ -993,11 +996,11 @@ public class TypeFactory {
         private TypeValues() {  }
 
         public Type randomType(TypeStore store, RandomTypesConfig config) {
-            Function<RandomTypesConfig,Type> next = new Function<RandomTypesConfig,Type>() {
+            BiFunction<TypeStore,RandomTypesConfig,Type> next = new BiFunction<TypeStore,RandomTypesConfig,Type>() {
                 int maxTries = config.getMaxDepth();
 
                 @Override
-                public Type apply(RandomTypesConfig rnd) {
+                public Type apply(TypeStore store, RandomTypesConfig rnd) {
                     if (maxTries-- > 0) {
                         return getRandomType(this, store, rnd);
                     }
@@ -1010,7 +1013,7 @@ public class TypeFactory {
             return config.getMaxDepth() > 0 ? getRandomType(next, store, config) : getRandomNonRecursiveType(next, store, config);
         }
 
-        private Type getRandomNonRecursiveType(Function<RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd) {
+        private Type getRandomNonRecursiveType(BiFunction<TypeStore,RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd) {
             Iterator<TypeReifier> it = symbolConstructorTypes.values().iterator();
             TypeReifier reifier = it.next();
 
@@ -1027,7 +1030,7 @@ public class TypeFactory {
             return reifier.randomInstance(next, store, rnd);
         }
 
-        private Type getRandomType(Function<RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd) {
+        private Type getRandomType(BiFunction<TypeStore,RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd) {
             TypeReifier[] alts = symbolConstructorTypes.values().toArray(new TypeReifier[0]);
             TypeReifier selected = alts[Math.max(0, alts.length > 0 ? rnd.nextInt(alts.length) - 1 : 0)];
 
@@ -1036,6 +1039,9 @@ public class TypeFactory {
                 selected = alts[Math.max(0, rnd.nextInt(alts.length))];
             }
 
+            // if (selected.getClass().toString().contains("AbstractDataType")) {
+            //     System.err.println("generating an ADT type instance");
+            // }
             return selected.randomInstance(next, store, rnd);
         }
 

--- a/src/main/java/io/usethesource/vallang/type/TypeReader.java
+++ b/src/main/java/io/usethesource/vallang/type/TypeReader.java
@@ -71,7 +71,7 @@ public class TypeReader {
                     return readComposite((t) -> types.abstractDataType(store, id, t.toArray(new Type[0])));
                 }
 
-                throw new TypeParseError("undeclared type " + id, new NullPointerException());
+                throw new TypeParseError("undeclared type " + id, new IllegalArgumentException());
             }
             else {
                 Type adt = store.lookupAbstractDataType(id);
@@ -79,7 +79,7 @@ public class TypeReader {
                     return adt;
                 }
 
-                throw new TypeParseError("undeclared type " + id, new NullPointerException());
+                throw new TypeParseError("undeclared type " + id, new IllegalArgumentException());
             }
         }
 

--- a/src/main/java/io/usethesource/vallang/type/ValueType.java
+++ b/src/main/java/io/usethesource/vallang/type/ValueType.java
@@ -15,6 +15,7 @@ package io.usethesource.vallang.type;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -51,7 +52,7 @@ import io.usethesource.vallang.type.TypeFactory.TypeValues;
         }
 
         @Override
-        public Type randomInstance(Function<RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd) {
+        public Type randomInstance(BiFunction<TypeStore, RandomTypesConfig, Type> next, TypeStore store, RandomTypesConfig rnd) {
             return tf().valueType();
         }
     }

--- a/src/main/java/io/usethesource/vallang/type/VoidType.java
+++ b/src/main/java/io/usethesource/vallang/type/VoidType.java
@@ -16,6 +16,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import io.usethesource.vallang.IConstructor;
 import io.usethesource.vallang.IValue;
@@ -57,7 +58,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
         }
 
         @Override
-        public Type randomInstance(Function<RandomTypesConfig,Type> next, TypeStore store, RandomTypesConfig rnd) {
+        public Type randomInstance(BiFunction<TypeStore, RandomTypesConfig, Type> next, TypeStore store, RandomTypesConfig rnd) {
             return tf().voidType();
         }
     }

--- a/src/test/java/io/usethesource/vallang/ValueProvider.java
+++ b/src/test/java/io/usethesource/vallang/ValueProvider.java
@@ -198,7 +198,13 @@ public class ValueProvider implements ArgumentsProvider {
             return allADTs.stream().skip(new Random().nextInt(allADTs.size())).findFirst().get();
         }
 
-        return TypeFactory.getInstance().randomADTType(ts, rtc);
+        if (rtc.isWithRandomAbstractDatatypes()) {
+            return TypeFactory.getInstance().randomADTType(ts, rtc);
+        }
+        else {
+            // try something else instead
+            return TypeFactory.getInstance().randomADTType(ts, rtc);
+        }
     }
 
     /**

--- a/src/test/java/io/usethesource/vallang/ValueProvider.java
+++ b/src/test/java/io/usethesource/vallang/ValueProvider.java
@@ -80,7 +80,7 @@ public class ValueProvider implements ArgumentsProvider {
     static {
         seedProperty = System.getProperty("vallang.test.seed");
         if (seedProperty != null) {
-            System.err.println("Current random seed is computed from -Dvallang.test.seed=" + seedProperty);
+            System.err.println("[INFO] Current random seed is computed from -Dvallang.test.seed=" + seedProperty);
             seed = hashSeed(seedProperty);
             rnd = new Random(seed);
         }
@@ -89,7 +89,7 @@ public class ValueProvider implements ArgumentsProvider {
             rnd = new Random(seed);
         }
 
-        System.err.println("Current random seed is: " + seed);
+        System.err.println("[INFO] Current random seed is: " + seed);
     }
 
     /**
@@ -199,18 +199,18 @@ public class ValueProvider implements ArgumentsProvider {
         }
 
         // note the side-effect in the type store!
-        Type x = tf.abstractDataType(ts, "X");
-        tf.constructor(ts, x, "x");
+        // Type x = tf.abstractDataType(ts, "X");
+        // tf.constructor(ts, x, "x");
 
-        return x;
+        // return x;
 
-        // if (rtc.isWithRandomAbstractDatatypes()) {
-        //     return TypeFactory.getInstance().randomADTType(ts, rtc);
-        // }
-        // else {
-        //     // try something else instead
-        //     return TypeFactory.getInstance().randomADTType(ts, rtc);
-        // }
+        if (rtc.isWithRandomAbstractDatatypes()) {
+            return TypeFactory.getInstance().randomADTType(ts, rtc);
+        }
+        else {
+            // try something else instead
+            return TypeFactory.getInstance().randomType(ts, rtc);
+        }
     }
 
     /**
@@ -412,7 +412,7 @@ public class ValueProvider implements ArgumentsProvider {
         try {
             return new StandardTextReader().read(vf, ts, val.getType(), new StringReader(val.toString()));
         } catch (FactTypeUseException | FactParseError | IOException e) {
-            System.err.println("WARNING: value reinstantation via serialization failed for ["+val+"] because + \""+e.getMessage()+"\". Reusing reference.");
+            System.err.println("[WARNING] value reinstantation via serialization failed for ["+val+"] because + \""+e.getMessage()+"\". Reusing reference.");
             return val;
         }
     }

--- a/src/test/java/io/usethesource/vallang/ValueProvider.java
+++ b/src/test/java/io/usethesource/vallang/ValueProvider.java
@@ -198,13 +198,19 @@ public class ValueProvider implements ArgumentsProvider {
             return allADTs.stream().skip(new Random().nextInt(allADTs.size())).findFirst().get();
         }
 
-        if (rtc.isWithRandomAbstractDatatypes()) {
-            return TypeFactory.getInstance().randomADTType(ts, rtc);
-        }
-        else {
-            // try something else instead
-            return TypeFactory.getInstance().randomADTType(ts, rtc);
-        }
+        // note the side-effect in the type store!
+        Type x = tf.abstractDataType(ts, "X");
+        tf.constructor(ts, x, "x");
+
+        return x;
+
+        // if (rtc.isWithRandomAbstractDatatypes()) {
+        //     return TypeFactory.getInstance().randomADTType(ts, rtc);
+        // }
+        // else {
+        //     // try something else instead
+        //     return TypeFactory.getInstance().randomADTType(ts, rtc);
+        // }
     }
 
     /**
@@ -330,7 +336,10 @@ public class ValueProvider implements ArgumentsProvider {
                         tc = tc.withMapFieldNames();
                         break;
                     case ALL:
-                        tc = tc.withAliases().withTupleFieldNames().withTypeParameters();
+                        tc = tc.withAliases()
+                            .withTupleFieldNames()
+                            .withTypeParameters()
+                            .withMapFieldNames();
                         break;
                 }
             }


### PR DESCRIPTION
During randomType recursive calls the `RandomTypeConfig rnd` parameter would be modified to tweak the output of the random generator. This has been removed such that the outer worker API can influence these parameters exclusively. This will fix a bug in the rascal project where too many labels were generated in several tests. 