### PR TITLE
workaround or fix for the npe during Rascal testing

### DIFF
--- a/src/main/java/io/usethesource/vallang/util/WeakReferenceHashConsingMap.java
+++ b/src/main/java/io/usethesource/vallang/util/WeakReferenceHashConsingMap.java
@@ -100,7 +100,11 @@ public class WeakReferenceHashConsingMap<T extends @NonNull Object> implements H
         public boolean equals(@Nullable Object obj) {
             if (obj instanceof WeakReferenceWrap<?>) {
                 var actual = (WeakReferenceWrap<?>)obj;
-                return actual.hash == hash && value.equals(actual.get());
+                var reference = actual.get();
+                if (reference != null) {
+                    // not garbage collected yet
+                    return actual.hash == hash && value.equals(reference);
+                }
             }
             return false;
         }


### PR DESCRIPTION
This behavior was consistenly observed on the `syntax-role-modifiers` branch, but not when running the tests from the REPL, only when running `mvn test`:

```
java.lang.NullPointerException
	at org.rascalmpl.types.ModifySyntaxRole.equals(ModifySyntaxRole.java:941)
	at io.usethesource.vallang.util.WeakReferenceHashConsingMap$LookupKey.equals(WeakReferenceHashConsingMap.java:103)
	at java.base/java.util.concurrent.ConcurrentHashMap.get(ConcurrentHashMap.java:940)
	at io.usethesource.vallang.util.WeakReferenceHashConsingMap.get(WeakReferenceHashConsingMap.java:202)
	at io.usethesource.vallang.type.TypeFactory.getFromCache(TypeFactory.java:130)
	at io.usethesource.vallang.type.TypeFactory.externalType(TypeFactory.java:187)
	at org.rascalmpl.types.RascalTypeFactory.modifyToLexical(RascalTypeFactory.java:134)
	at org.rascalmpl.semantics.dynamic.SyntaxRoleModifier$Lexical.typeOf(SyntaxRoleModifier.java:51)
	at org.rascalmpl.semantics.dynamic.Type$Modifier.typeOf(Type.java:148)
	at org.rascalmpl.semantics.dynamic.Expression$TypedVariable.typeOf(Expression.java:2849)
	at org.rascalmpl.semantics.dynamic.Formals$Default.typeOf(Formals.java:42)
	at org.rascalmpl.semantics.dynamic.Parameters$Default.typeOf(Parameters.java:35)
	at org.rascalmpl.semantics.dynamic.Signature$NoThrows.typeOf(Signature.java:50)
	at org.rascalmpl.interpreter.result.RascalFunction.<init>(RascalFunction.java:91)
	at org.rascalmpl.semantics.dynamic.FunctionDeclaration$Expression.interpret(FunctionDeclaration.java:144)
	at org.rascalmpl.semantics.dynamic.Statement$FunctionDeclaration.interpret(Statement.java:546)
	at org.rascalmpl.interpreter.result.RascalFunction.runBody(RascalFunction.java:384)
	at org.rascalmpl.interpreter.result.RascalFunction.call(RascalFunction.java:293)
	at org.rascalmpl.interpreter.result.ICallableValue.call(ICallableValue.java:50)
	at org.rascalmpl.interpreter.result.AbstractFunction.call(AbstractFunction.java:208)
	at org.rascalmpl.values.functions.IFunction.call(IFunction.java:48)
	at org.rascalmpl.interpreter.TestEvaluator.lambda$1(TestEvaluator.java:125)
	at org.rascalmpl.test.infrastructure.QuickCheck.test(QuickCheck.java:112)
	at org.rascalmpl.interpreter.TestEvaluator.lambda$0(TestEvaluator.java:123)
	at org.rascalmpl.debug.IRascalMonitor.job(IRascalMonitor.java:68)
	at org.rascalmpl.interpreter.TestEvaluator.runTests(TestEvaluator.java:94)
	at org.rascalmpl.interpreter.TestEvaluator.test(TestEvaluator.java:54)
	at org.rascalmpl.test.infrastructure.RascalJUnitParallelRecursiveTestRunner$ModuleTester.lambda$0(RascalJUnitParallelRecursiveTestRunner.java:216)
	at org.rascalmpl.debug.IRascalMonitor.job(IRascalMonitor.java:68)
	at org.rascalmpl.test.infrastructure.RascalJUnitParallelRecursiveTestRunner$ModuleTester.runTests(RascalJUnitParallelRecursiveTestRunner.java:202)
	at org.rascalmpl.test.infrastructure.RascalJUnitParallelRecursiveTestRunner$ModuleTester.run(RascalJUnitParallelRecursiveTestRunner.java:196)
```

It is always during the second run that the bug triggers:

```
[ERROR] Errors: 
[ERROR] org.rascalmpl.test.infrastructure.RascalJUnitParallelRecursiveTestRunner$ModuleTester.dataMatchesSyntaxTreesToo2: <2506,523>
[INFO]   Run 1: PASS
[ERROR]   Run 2: RascalJUnitParallelRecursiveTestRunner$ModuleTester.run:196->runTests:202->lambda$0:216 » NullPointer
[INFO] 
[ERROR] org.rascalmpl.test.infrastructure.RascalJUnitParallelRecursiveTestRunner$ModuleTester.dispatchingOnSyntaxRole: <379,250>
[INFO]   Run 1: PASS
[ERROR]   Run 2: RascalJUnitParallelRecursiveTestRunner$ModuleTester.run:196->runTests:202->lambda$0:216 » NullPointer
[INFO] 
[ERROR] org.rascalmpl.test.infrastructure.RascalJUnitParallelRecursiveTestRunner$ModuleTester.namePreservation1: <1155,641>
[INFO]   Run 1: PASS
[ERROR]   Run 2: RascalJUnitParallelRecursiveTestRunner$ModuleTester.run:196->runTests:202->lambda$0:216 » NullPointer
[INFO] 
[ERROR] org.rascalmpl.test.infrastructure.RascalJUnitParallelRecursiveTestRunner$ModuleTester.namePreservation2: <1798,617>
[INFO]   Run 1: PASS
[ERROR]   Run 2: RascalJUnitParallelRecursiveTestRunner$ModuleTester.run:196->runTests:202->lambda$0:216 » NullPointer
[INFO] 
```

It is unclear to me what this "Run 2" means and why it is triggered. It is clear that the garbage collector seems to have cleaned up the type that we are looking for when we run the test again.